### PR TITLE
Update parwv.c

### DIFF
--- a/c/parwv.c
+++ b/c/parwv.c
@@ -630,7 +630,7 @@ void pitch_synch_par_reset(void) {
 
 
 /*        Reset a & b, which determine shape of "natural" glottal waveform */
-            b = B0[nopen-40];
+            b = Bzero[nopen-40];
                 a = (b * nopen) * .333;
 
 /*        Reset width of "impulsive" glottal pulse */


### PR DESCRIPTION
With Xcode 8.0, mixed alpha-numeric characters for parameter names (like B0) won't compile. I can't tell if this is a bug in Xcode that they're going to fix or if it's working as intended, but I couldn't run this with Python 3.X on OSX 10.12.1 and higher.