### PR TITLE
Fix building on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ import numpy
 math_lib = ["m"]
 
 if platform.platform()[:7] == "Windows":
-  print("Windows Found - Removing Linking to Math.lib")
   math_lib = []
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,23 @@
 
 from distutils.core import setup
 from distutils.extension import Extension
+import platform
 from Cython.Distutils import build_ext
 import numpy
+
+
+math_lib = ["m"]
+
+if platform.platform()[:7] == "Windows":
+  print("Windows Found - Removing Linking to Math.lib")
+  math_lib = []
+
 
 ext_modules = [
   Extension(
     name="klsyn.klatt_wrap",
     sources=["klsyn/klatt_wrap.pyx"],
-    libraries = ["m"],
+    libraries = math_lib,
     include_dirs=[numpy.get_include()],
     language="c",
   )


### PR DESCRIPTION
Building on windows uses msvc, which does not use external linking of the math libs "m.lib". Checking if we're on Windows in setup.py and removing this library link in that circumstance fixes this. Tested py2.7/3.5 on windows and ubuntu 14.04.